### PR TITLE
Fix for OSX

### DIFF
--- a/deps/ext.jl
+++ b/deps/ext.jl
@@ -1,1 +1,1 @@
-const _jl_libGLPK = joinpath(Pkg.dir(), "GLPK", "deps", "usr", "lib", "libglpk.so")
+const _jl_libGLPK = joinpath(Pkg.dir(), "GLPK", "deps", "usr", "lib", "libglpk")


### PR DESCRIPTION
Changes ext.jl to not hardcode .so extension, fixes on OSX, not sure about Linux or Windows.
