### PR TITLE
use URL for brew formula

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,7 @@ glpkdep = library_dependency("libglpk", validate = ((name,handle)->(bytestring(c
 provides(Sources, {URI("http://ftp.gnu.org/gnu/glpk/$glpkname.tar.gz") => glpkdep}, os = :Unix)
 provides(Sources, {URI("http://downloads.sourceforge.net/project/winglpk/winglpk/GLPK-$glpkvers/win$glpkname.zip") => glpkdep}, os = :Windows)
 
-provides(Homebrew, {"libglpk" => glpkdep})
+provides(Homebrew, {"https://raw.github.com/Homebrew/homebrew-science/master/glpk.rb" => glpkdep})
 
 provides(BuildProcess, {
     Autotools(libtarget = joinpath("src", ".libs", "libglpk.la"), configure_options = String["--with-gmp", "--enable-dl"]) => glpkdep


### PR DESCRIPTION
This fixes the `homebrew/science` issue. GLPK seems to install fine and the tests pass. Another issue is that homebrew isn't even currently enabled on OS X: loladiro/BinDeps.jl#34. 
