### PR TITLE
Use relative paths instead of Pkg.dir("GLPK")

### DIFF
--- a/src/GLPK.jl
+++ b/src/GLPK.jl
@@ -188,7 +188,7 @@ import Base.setindex!, Base.getindex
 
 ## Shared library interface setup
 #{{{
-if isfile(joinpath(Pkg.dir("GLPK"),"deps","deps.jl"))
+if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
     include("../deps/deps.jl")
 else
     error("GLPK not properly installed. Please run Pkg.build(\"GLPK\")")

--- a/test/glpk_tst_2.jl
+++ b/test/glpk_tst_2.jl
@@ -6,7 +6,7 @@ import GLPK
 function glpk_tst_2()
     prev_term_out = GLPK.term_out(GLPK.OFF)
 
-    datadir = joinpath(Pkg.dir(), "GLPK", "test", "data")
+    datadir = joinpath(dirname(@__FILE__), "data")
     isdir(datadir) || (datadir = joinpath(Pkg.dir(), "GLPK.jl", "test", "data"))
 
     lp = GLPK.Prob()

--- a/test/glpk_tst_3.jl
+++ b/test/glpk_tst_3.jl
@@ -6,7 +6,7 @@ import GLPK
 function glpk_tst_3()
     prev_term_out = GLPK.term_out(GLPK.OFF)
 
-    datadir = joinpath(Pkg.dir(), "GLPK", "test", "data")
+    datadir = joinpath(dirname(@__FILE__), "data")
     isdir(datadir) || (datadir = joinpath(Pkg.dir(), "GLPK.jl", "test", "data"))
 
     lp = GLPK.Prob()

--- a/test/glpk_tst_4.jl
+++ b/test/glpk_tst_4.jl
@@ -17,7 +17,7 @@ end
 function glpk_tst_4()
     prev_term_out = GLPK.term_out(GLPK.OFF)
 
-    datadir = joinpath(Pkg.dir(), "GLPK", "test", "data")
+    datadir = joinpath(dirname(@__FILE__), "data")
     isdir(datadir) || (datadir = joinpath(Pkg.dir(), "GLPK.jl", "test", "data"))
 
     mip = GLPK.Prob()

--- a/test/glpk_tst_5.jl
+++ b/test/glpk_tst_5.jl
@@ -2,7 +2,7 @@ using Base.Test
 import GLPK
 
 function glpk_tst_5()
-    datadir = joinpath(Pkg.dir(), "GLPK", "test", "data")
+    datadir = joinpath(dirname(@__FILE__), "data")
     isdir(datadir) || (datadir = joinpath(Pkg.dir(), "GLPK.jl", "test", "data"))
 
     prev_term_out = GLPK.term_out(GLPK.OFF)

--- a/test/glpk_tst_6.jl
+++ b/test/glpk_tst_6.jl
@@ -2,7 +2,7 @@ using Base.Test
 import GLPK
 
 function glpk_tst_6()
-    datadir = joinpath(Pkg.dir(), "GLPK", "test", "data")
+    datadir = joinpath(dirname(@__FILE__), "data")
     isdir(datadir) || (datadir = joinpath(Pkg.dir(), "GLPK.jl", "test", "data"))
 
     prev_term_out = GLPK.term_out(GLPK.OFF)


### PR DESCRIPTION
this allows installing in a non-default location