### PR TITLE
Fix the WORD_SIZE dep warn

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -57,6 +57,6 @@ end
 
 # Windows
 provides(Binaries, URI("https://bintray.com/artifact/download/tkelman/generic/win$glpkname.zip"),
-         glpkdep, unpacked_dir="$glpkname/w$WORD_SIZE", os = :Windows)
+         glpkdep, unpacked_dir="$glpkname/w$(Sys.WORD_SIZE)", os = :Windows)
 
 @compat @BinDeps.install Dict(:libglpk => :libglpk)


### PR DESCRIPTION
`WORD_SIZE` -> `Sys.WORD_SIZE`. Works on 0.3, 0.4, and 0.5.