### PR TITLE
Add a check for word size in test_5

### DIFF
--- a/test/glpk_tst_5.jl
+++ b/test/glpk_tst_5.jl
@@ -18,7 +18,7 @@ function glpk_tst_5()
     finally
         isfile(cnfcopy) && rm(cnfcopy)
     end
-    if GLPK.version() >= (4, 57)
+    if GLPK.version() >= (4, 57) && Sys.WORD_SIZE != sizeof(Cint) * 8
         # in api/minisat1.c, there is:
         #if (sizeof(void *) != sizeof(int))
         #{  xprintf("glp_minisat1: sorry, MiniSat solver is not supported "


### PR DESCRIPTION
I forgot to add this check. In fact this is not covered by Travis or AppVeyor since only AppVeyor has 32 bits but the GLPK version for Windows is below v4.57.