### PR TITLE
Use WinRPM for Windows

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 BinDeps
 @osx Homebrew
 Compat 0.17
+@windows WinRPM

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,6 +19,7 @@ depends = []
     gmpdep = library_dependency("libgmp", aliases = ["libgmp-10", "libgmp10"])
     push!(depends, gmpdep)
 end
+@show depends
 glpkdep = library_dependency("libglpk", aliases = ["libglpk-40"], # it is called libglpk-40 on the glpk-devel WinRPM package
                              depends = depends, validate = glpkvalidate)
 
@@ -49,4 +50,4 @@ end
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 
-@BinDeps.install Dict(:libglpk => :libglpk)
+@BinDeps.install Dict(:libgmp => :libgmp, :libglpk => :libglpk)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -52,7 +52,6 @@ end
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 
-@show BinDeps.debug("libgmp10")
-@show BinDeps.debug("glpk-devel")
+@show BinDeps.debug("GLPK")
 
 @BinDeps.install Dict(:libglpk => :libglpk)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -42,9 +42,6 @@ end
     # GMP
     using WinRPM
     WinRPM.install("libgmp10", yes = true)
-    push!(WinRPM.sources, "https://cache.julialang.org/http://download.opensuse.org/repositories/home:/blegat:/branches:/windows:/mingw:/win32/openSUSE_13.2")
-    push!(WinRPM.sources, "https://cache.julialang.org/http://download.opensuse.org/repositories/home:/blegat:/branches:/windows:/mingw:/win64/openSUSE_13.2")
-    WinRPM.update()
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,8 +14,14 @@ function glpkvalidate(name, handle)
     ver = VersionNumber(ver_str)
     glpkminver <= ver <= glpkmaxver
 end
+@static if is_windows()
+    gmpdep = library_dependency("libgmp", aliases = ["libgmp-10", "libgmp10"])
+    depends = [gmpdep]
+else
+    depends = []
+end
 glpkdep = library_dependency("libglpk", aliases = ["libglpk-40"], # it is called libglpk-40 on the glpk-devel WinRPM package
-                             validate = glpkvalidate)
+                             validate = glpkvalidate, depends=depends)
 
 # Build from sources (used by Linux, BSD)
 julia_usrdir = normpath("$JULIA_HOME/../") # This is a stopgap, we need a better builtin solution to get the included libraries
@@ -39,9 +45,7 @@ end
 
 # Windows
 @static if is_windows()
-    # GMP
-    using WinRPM
-    WinRPM.install("libgmp10", yes = true)
+    provides(WinRPM.RPM, "libgmp10", [gmpdep], os = :Windows)
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,7 +16,9 @@ function glpkvalidate(name, handle)
 end
 depends = []
 @static if is_windows()
-    gmpdep = library_dependency("libgmp", aliases = ["libgmp-10", "libgmp10"])
+    # If it is called libgmp, it will detect julia/bin/libgmp.dll but libglpk doesn't seem be be satisfied
+    # with it, we need to install libgmp10.
+    gmpdep = library_dependency("libgmp10", aliases = ["libgmp-10", "libgmp10"])
     push!(depends, gmpdep)
 end
 @show depends
@@ -50,4 +52,7 @@ end
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 
-@BinDeps.install Dict(:libgmp => :libgmp)
+@show BinDeps.debug("libgmp10")
+@show BinDeps.debug("glpk-devel")
+
+@BinDeps.install Dict(:libglpk => :libglpk)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -41,6 +41,8 @@ end
 @static if is_windows()
     using WinRPM
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
+    provides(WinRPM.RPM, "libglpk40", [glpkdep], os = :Windows)
+    provides(WinRPM.RPM, "glpk", [glpkdep], os = :Windows)
 end
 
 @BinDeps.install Dict(:libglpk => :libglpk)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,14 +14,13 @@ function glpkvalidate(name, handle)
     ver = VersionNumber(ver_str)
     glpkminver <= ver <= glpkmaxver
 end
+depends = []
 @static if is_windows()
     gmpdep = library_dependency("libgmp", aliases = ["libgmp-10", "libgmp10"])
-    depends = [gmpdep]
-else
-    depends = []
+    push!(depends, gmpdep)
 end
 glpkdep = library_dependency("libglpk", aliases = ["libglpk-40"], # it is called libglpk-40 on the glpk-devel WinRPM package
-                             validate = glpkvalidate, depends=depends)
+                             depends = depends, validate = glpkvalidate)
 
 # Build from sources (used by Linux, BSD)
 julia_usrdir = normpath("$JULIA_HOME/../") # This is a stopgap, we need a better builtin solution to get the included libraries

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -50,4 +50,4 @@ end
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 
-@BinDeps.install Dict(:libgmp => :libgmp, :libglpk => :libglpk)
+@BinDeps.install Dict(:libgmp => :libgmp)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,7 +14,7 @@ function glpkvalidate(name, handle)
     ver = VersionNumber(ver_str)
     glpkminver <= ver <= glpkmaxver
 end
-glpkdep = library_dependency("libglpk", aliases = [glpkdllname,glpkwindllname],
+glpkdep = library_dependency("libglpk", aliases = ["libglpk-40"], # it is called libglpk-40 on the glpk-devel WinRPM package
                              validate = glpkvalidate)
 
 # Build from sources (used by Linux, BSD)
@@ -38,7 +38,14 @@ if is_apple()
 end
 
 # Windows
-provides(Binaries, URI("https://bintray.com/artifact/download/tkelman/generic/win$glpkwinname.zip"),
-         glpkdep, unpacked_dir="$glpkwinname/w$(Sys.WORD_SIZE)", os = :Windows)
+@static if is_windows()
+    # GMP
+    using WinRPM
+    WinRPM.install("libgmp10", yes = true)
+    push!(WinRPM.sources, "https://cache.julialang.org/http://download.opensuse.org/repositories/home:/blegat:/branches:/windows:/mingw:/win32/openSUSE_13.2")
+    push!(WinRPM.sources, "https://cache.julialang.org/http://download.opensuse.org/repositories/home:/blegat:/branches:/windows:/mingw:/win64/openSUSE_13.2")
+    WinRPM.update()
+    provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
+end
 
 @BinDeps.install Dict(:libglpk => :libglpk)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -52,6 +52,4 @@ end
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 
-@show BinDeps.debug("GLPK")
-
 @BinDeps.install Dict(:libglpk => :libglpk)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -44,6 +44,7 @@ end
 
 # Windows
 @static if is_windows()
+    using WinRPM
     provides(WinRPM.RPM, "libgmp10", [gmpdep], os = :Windows)
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,16 +14,8 @@ function glpkvalidate(name, handle)
     ver = VersionNumber(ver_str)
     glpkminver <= ver <= glpkmaxver
 end
-depends = []
-@static if is_windows()
-    # If it is called libgmp, it will detect julia/bin/libgmp.dll but libglpk doesn't seem be be satisfied
-    # with it, we need to install libgmp10.
-    gmpdep = library_dependency("libgmp10", aliases = ["libgmp-10", "libgmp10"])
-    push!(depends, gmpdep)
-end
-@show depends
 glpkdep = library_dependency("libglpk", aliases = ["libglpk-40"], # it is called libglpk-40 on the glpk-devel WinRPM package
-                             depends = depends, validate = glpkvalidate)
+                             validate = glpkvalidate)
 
 # Build from sources (used by Linux, BSD)
 julia_usrdir = normpath("$JULIA_HOME/../") # This is a stopgap, we need a better builtin solution to get the included libraries
@@ -48,7 +40,6 @@ end
 # Windows
 @static if is_windows()
     using WinRPM
-    provides(WinRPM.RPM, "libgmp10", [gmpdep], os = :Windows)
     provides(WinRPM.RPM, "glpk-devel", [glpkdep], os = :Windows)
 end
 

--- a/deps/verreq.jl
+++ b/deps/verreq.jl
@@ -3,7 +3,7 @@
 const glpkminver = v"4.52" # Minimum requirement
 const glpkmaxver = v"4.61" # Maximum version known to work
 const glpkdefver = "4.61"  # Default version
-const glpkwinver = "4.52"  # Default version for windows
+const glpkwinver = "4.61"  # Default version for windows
 
 function check_glpk_version(major_ver, minor_ver)
     if !(glpkminver <= VersionNumber(major_ver, minor_ver) <= glpkmaxver)


### PR DESCRIPTION
I currently get the following error when running `glp_test_1`, it is discussed [here](https://lists.gnu.org/archive/html/bug-glpk/2013-06/msg00012.html).
@tkelman How did you build the dll ?
```
Please submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.
Exception: EXCEPTION_ACCESS_VIOLATION at 0x6a8271d0 -- glp_time at /home/abuild/rpmbuild/BUILD/glpk-4.61/src\env\time.c:61
while loading C:\Users\appveyor\.julia\v0.5\GLPK\test\glpk_tst_1.jl, in expression starting on line 297
gmtime at /home/abuild/rpmbuild/BUILD/glpk-4.61/src/usr/x86_64-w64-mingw32/sys-root/mingw/include\time.h:217 [inlined]
glp_time at /home/abuild/rpmbuild/BUILD/glpk-4.61/src\env\time.c:60
_glp_spx_primal at /home/abuild/rpmbuild/BUILD/glpk-4.61/src\simplex\spxprim.c:1125
```
Closes #14 #17 