### PR TITLE
add support for libglpk 4.62

### DIFF
--- a/deps/verreq.jl
+++ b/deps/verreq.jl
@@ -1,7 +1,7 @@
 # Version requirements for libglpk
 
 const glpkminver = v"4.52" # Minimum requirement
-const glpkmaxver = v"4.61" # Maximum version known to work
+const glpkmaxver = v"4.62" # Maximum version known to work
 const glpkdefver = "4.61"  # Default version
 const glpkwinver = "4.52"  # Default version for windows
 

--- a/test/glpk_tst_5.jl
+++ b/test/glpk_tst_5.jl
@@ -27,6 +27,11 @@ function glpk_tst_5()
         #   goto done;
         #}
         expected_ret = GLPK.EFAIL
+
+    elseif (4, 62) <= GLPK.version() && Sys.WORD_SIZE != sizeof(Csize_t) * 8
+        # changed condition to:
+        # if (sizeof(void *) != sizeof(size_t))
+        expected_ret = GLPK.EFAIL
     else
         expected_ret = 0
     end

--- a/test/glpk_tst_5.jl
+++ b/test/glpk_tst_5.jl
@@ -18,7 +18,7 @@ function glpk_tst_5()
     finally
         isfile(cnfcopy) && rm(cnfcopy)
     end
-    if GLPK.version() >= (4, 57) && Sys.WORD_SIZE != sizeof(Cint) * 8
+    if (4, 57) <= GLPK.version() <= (4, 61) && Sys.WORD_SIZE != sizeof(Cint) * 8
         # in api/minisat1.c, there is:
         #if (sizeof(void *) != sizeof(int))
         #{  xprintf("glp_minisat1: sorry, MiniSat solver is not supported "


### PR DESCRIPTION
My Manjaro box just received the recently released libglpk 4.62

Looks like something the MiniSat solver is now supported (based on the test that I had to chage). 

Tests are passing on my system.