### PR TITLE
drop support for julia 0.5 and fix build on 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 env:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 BinDeps
 @osx Homebrew
 Compat 0.17

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,7 +18,12 @@ glpkdep = library_dependency("libglpk", aliases = [glpkdllname,glpkwindllname],
                              validate = glpkvalidate)
 
 # Build from sources (used by Linux, BSD)
-julia_usrdir = normpath("$JULIA_HOME/../") # This is a stopgap, we need a better builtin solution to get the included libraries
+if VERSION >= v"0.7-"
+    bindir = Base.Sys.BINDIR
+else
+    bindir = JULIA_HOME
+end
+julia_usrdir = normpath("$bindir/../") # This is a stopgap, we need a better builtin solution to get the included libraries
 libdirs = String["$(julia_usrdir)/lib"]
 includedirs = String["$(julia_usrdir)/include"]
 


### PR DESCRIPTION
I'm getting a segfault when running the tests, but by dropping 0.5 we can at least run femtocleaner to fix some deprecations.