### PR TITLE
clean up travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,18 @@ julia:
   - 1.0
   - nightly
 env:
-  matrix:
-    - CC="gcc"
-    - CC="clang"
+  - CC="gcc"
+  - CC="clang"
 matrix:
   allow_failures:
     - julia: nightly
 notifications:
   email: false
-sudo: false # use a docker worker
 addons:
   apt_packages:
   - libgmp-dev
-
-# This replaces the `git fetch --unshallow` in the default Julia Travis script
-git:
-  depth: 99999999
-
-script:
-  - julia --check-bounds=yes -e 'if VERSION < v"0.7-"; Pkg.clone(pwd()); else; import Pkg; Pkg.add(Pkg.PackageSpec(path=pwd())); end; Pkg.build("GLPK"); Pkg.test("GLPK"; coverage=true)'
-
 after_success:
-  - julia --check-bounds=yes --inline=no -e 'if VERSION >= v"0.7-"; import Pkg; end; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  - julia -e 'if VERSION >= v"0.7-"; import Pkg; end; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 branches:
   except:
     - release-0.1


### PR DESCRIPTION
The default travis `script` should work just fine and be a bit more future-proof. Also, I wonder if the custom travis script we currently have is the reason that the code coverage is broken. 