### PR TITLE
Remove nightly and compiler builds from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,6 @@ julia:
   - 0.6
   - 0.7
   - 1.0
-  - nightly
-env:
-  - CC="gcc"
-  - CC="clang"
-matrix:
-  allow_failures:
-    - julia: nightly
 notifications:
   email: false
 addons:


### PR DESCRIPTION
16 travis combinations is a bit excessive and clogs up the JuliaOpt queue. I don't recall ever finding a bug related to clang vs gcc.

@rdeits