### PR TITLE
Don't run the Travis build on every push to every branch 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,9 @@ notifications:
 addons:
   apt_packages:
   - libgmp-dev
+branches:
+  only:
+    - master
+    - /^release-.*$/
 after_success:
   - julia -e 'if VERSION >= v"0.7-"; import Pkg; end; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'


### PR DESCRIPTION
In the interest of reducing our travis usage and backlog, this turns off push builds except for master and any `release-` branches we might want to make. 