### PR TITLE
Fix deprecated warn

### DIFF
--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -114,7 +114,7 @@ function Optimizer(;presolve=false, method=:Simplex, kwargs...)
         set_intopt   = set_parameter(optimizer.intopt, key, value)
         set_simplex  = set_parameter(optimizer.simplex, key, value)
         if !set_interior && !set_intopt && !set_simplex
-            warn("Ignoring option: $(key) => $(value)")
+            Compat.@warn("Ignoring option: $(key) => $(value)")
         end
     end
     return optimizer


### PR DESCRIPTION
Fix deprecated `warn` in MOIWrapper.jl. (https://github.com/JuliaOpt/GLPK.jl/issues/88)
This raised an `UndefVarError` when an invalid option was passed to `GLPK.Optimizer`

Before: see https://github.com/JuliaOpt/GLPK.jl/issues/88

After:
```julia
julia> Model(with_optimizer(GLPK.Optimizer, XXX=1))
┌ Warning: Ignoring option: XXX => 
└ @ GLPK ~/.julia/dev/GLPK/src/MOIWrapper.jl:117    
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: GLPK
```