### PR TITLE
Rename platform_key -> platform_key_abi

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -28,8 +28,8 @@ download_info = Dict(
 
 # Install unsatisfied or updated dependencies:
 unsatisfied = any(!satisfied(p; verbose=verbose) for p in products)
-if haskey(download_info, platform_key())
-    url, tarball_hash = download_info[platform_key()]
+if haskey(download_info, platform_key_abi())
+    url, tarball_hash = download_info[platform_key_abi()]
     # Check if this build.jl is providing new versions of the binaries, and
     # if so, ovewrite the current binaries even if they were installed by the user 
     if unsatisfied || !isinstalled(url, tarball_hash; prefix=prefix) 
@@ -41,7 +41,7 @@ elseif unsatisfied
     # If we don't have a BinaryProvider-compatible .tar.gz to download, complain.
     # Alternatively, you could attempt to install from a separate provider,
     # build from source or something even more ambitious here.
-    error("Your platform $(triplet(platform_key())) is not supported by this package!")
+    error("Your platform $(triplet(platform_key_abi())) is not supported by this package!")
 end
 
 # Write out a deps.jl file that will contain mappings for our products

--- a/deps/build_GMP.v6.1.2.jl
+++ b/deps/build_GMP.v6.1.2.jl
@@ -29,8 +29,8 @@ download_info = Dict(
 
 # Install unsatisfied or updated dependencies:
 unsatisfied = any(!satisfied(p; verbose=verbose) for p in products)
-if haskey(download_info, platform_key())
-    url, tarball_hash = download_info[platform_key()]
+if haskey(download_info, platform_key_abi())
+    url, tarball_hash = download_info[platform_key_abi()]
     if unsatisfied || !isinstalled(url, tarball_hash; prefix=prefix)
         # Download and install binaries
         install(url, tarball_hash; prefix=prefix, force=true, verbose=verbose)
@@ -39,7 +39,7 @@ elseif unsatisfied
     # If we don't have a BinaryProvider-compatible .tar.gz to download, complain.
     # Alternatively, you could attempt to install from a separate provider,
     # build from source or something even more ambitious here.
-    error("Your platform $(triplet(platform_key())) is not supported by this package!")
+    error("Your platform $(triplet(platform_key_abi())) is not supported by this package!")
 end
 
 # Write out a deps.jl file that will contain mappings for our products


### PR DESCRIPTION
`platform_key` is deprecated:
https://github.com/JuliaPackaging/BinaryProvider.jl/blob/master/src/CompatShims.jl#L8-L13
With this change, the error goes from 
```
┌ Error: Error building `CDDLib`: 
│ ┌ Warning: platform_key() is deprecated, use platform_key_abi() from now on
│ │   caller = ip:0x0
│ └ @ Core :-1
│ [ Info: Downloading https://github.com/JuliaMath/GMPBuilder/releases/download/v6.1.2-2/GMP.v6.1.2.x86_64-linux-gnu.tar.gz to /home/blegat/.julia/dev/CDDLib/deps/usr/downloads/GMP.v6.1.2.x86_64-linux-gnu.tar.gz...
│ [ Info: Downloading https://github.com/benlorenz/cddlibBuilder/releases/download/v0.94.0-j/cddlibBuilder.v0.94.0-j.x86_64-linux-gnu.tar.gz to /home/blegat/.julia/dev/CDDLib/deps/usr/downloads/cddlibBuilder.v0.94.0-j.x86_64-linux-gnu.tar.gz...
│ ERROR: LoadError: Could not download https://github.com/benlorenz/cddlibBuilder/releases/download/v0.94.0-j/cddlibBuilder.v0.94.0-j.x86_64-linux-gnu.tar.gz to /home/blegat/.julia/dev/CDDLib/deps/usr/downloads/cddlibBuilder.v0.94.0-j.x86_64-linux-gnu.tar.gz:
│ ErrorException("")
│ Stacktrace:
│  [1] #download#89(::Bool, ::Function, ::String, ::String) at /home/blegat/.julia/packages/BinaryProvider/4F5Hq/src/PlatformEngines.jl:498
│  [2] #download at ./none:0 [inlined]
│  [3] #download_verify#90(::Bool, ::Bool, ::Bool, ::Function, ::String, ::String, ::String) at /home/blegat/.julia/packages/BinaryProvider/4F5Hq/src/PlatformEngines.jl:567
│  [4] #download_verify at ./none:0 [inlined]
│  [5] #install#129(::Prefix, ::String, ::Bool, ::Bool, ::Bool, ::Function, ::String, ::String) at /home/blegat/.julia/packages/BinaryProvider/4F5Hq/src/Prefix.jl:314
│  [6] (::getfield(BinaryProvider, Symbol("#kw##install")))(::NamedTuple{(:prefix, :force, :verbose),Tuple{Prefix,Bool,Bool}}, ::typeof(install), ::String, ::String) at ./none:0
│  [7] top-level scope at /home/blegat/.julia/dev/CDDLib/deps/build.jl:38
│  [8] include(::String) at ./client.jl:403
│  [9] top-level scope at none:0
│ in expression starting at /home/blegat/.julia/dev/CDDLib/deps/build.jl:31
[12:56:47] ######################################################################## 100.0% 
[12:56:48] ##O=#  #                                                                        
│ [12:56:48] curl: (22) The requested URL returned error: 404 Not Found
└ @ Pkg.Operations /build/julia/src/julia-1.1.0/usr/share/julia/stdlib/v1.1/Pkg/src/Operations.jl:1075
```
to
```
(v1.1) pkg> build CDDLib
  Building LibCURL ─────────→ `~/.julia/packages/LibCURL/khRkY/deps/build.log`
  Building WinRPM ──────────→ `~/.julia/packages/WinRPM/Y9QdZ/deps/build.log`
  Building Homebrew ────────→ `~/.julia/packages/Homebrew/s09IX/deps/build.log`
  Building SpecialFunctions → `~/.julia/packages/SpecialFunctions/fvheQ/deps/build.log`
  Building CDDLib ──────────→ `~/.julia/dev/CDDLib/deps/build.log`
 Resolving package versions...
┌ Error: Error building `CDDLib`: 
│ ERROR: LoadError: Your platform x86_64-linux-gnu-gcc8-cxx11 is not supported by this package!
│ Stacktrace:
│  [1] top-level scope at /home/blegat/.julia/dev/CDDLib/deps/build.jl:44
│  [2] include(::String) at ./client.jl:403
│  [3] top-level scope at none:0
│ in expression starting at /home/blegat/.julia/dev/CDDLib/deps/build.jl:31
└ @ Pkg.Operations /build/julia/src/julia-1.1.0/usr/share/julia/stdlib/v1.1/Pkg/src/Operations.jl:1075
```
The name is CDDLib instead of GLPK but since I started on CDDLib with a copy-paste from GLPK, it's the same.

CC @juan-pablo-vielma 