### PR TITLE
bugfix for TimeLimitSec and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To switch back to the default binaries clear `JULIA_GLPK_LIBRARY_PATH` and call 
 ## `GLPK.Optimizer`
 
 Use `GLPK.Optimizer` to create a new optimizer object:
+
+In the following examples the time limit is set to one minute and logging is turned off.
 ```julia
 using GLPK
 model = GLPK.Optimizer(tm_lim = 60000, msg_lev = GLPK.OFF)

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ To switch back to the default binaries clear `JULIA_GLPK_LIBRARY_PATH` and call 
 Use `GLPK.Optimizer` to create a new optimizer object:
 ```julia
 using GLPK
-model = GLPK.Optimizer(tm_lim = 60.0, msg_lev = GLPK.OFF)
+model = GLPK.Optimizer(tm_lim = 60000, msg_lev = GLPK.OFF)
 ```
 For JuMP, use:
 ```julia
 using JuMP, GLPK
 model = Model(
-    with_optimizer(GLPK.Optimizer, tm_lim = 60.0, msg_lev = GLPK.OFF)
+    with_optimizer(GLPK.Optimizer, tm_lim = 60000, msg_lev = GLPK.OFF)
 )
 ```
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -290,13 +290,19 @@ function MOI.get(model::Optimizer, param::MOI.RawParameter)
     error("Unable to get RawParameter. Invalid name: $(name)")
 end
 
-function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Real)
-    MOI.set(model, MOI.RawParameter("tm_lim"), limit)
+function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Union{Nothing,Real})
+    if limit === nothing
+        MOI.set(model, MOI.RawParameter("tm_lim"), typemax(Int32))
+    else
+        limit_ms = floor(limit*1000)
+        MOI.set(model, MOI.RawParameter("tm_lim"), limit_ms) 
+    end
     return
 end
 
 function MOI.get(model::Optimizer, ::MOI.TimeLimitSec)
-    return MOI.get(model, MOI.RawParameter("tm_lim"))
+    # convert internal ms to sec
+    return MOI.get(model, MOI.RawParameter("tm_lim"))/1000 
 end
 
 MOI.Utilities.supports_default_copy_to(::Optimizer, ::Bool) = true

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -294,7 +294,7 @@ function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, limit::Union{Nothing,Real
     if limit === nothing
         MOI.set(model, MOI.RawParameter("tm_lim"), typemax(Int32))
     else
-        limit_ms = floor(limit*1000)
+        limit_ms = ceil(Int32, limit * 1000)
         MOI.set(model, MOI.RawParameter("tm_lim"), limit_ms) 
     end
     return
@@ -302,7 +302,7 @@ end
 
 function MOI.get(model::Optimizer, ::MOI.TimeLimitSec)
     # convert internal ms to sec
-    return MOI.get(model, MOI.RawParameter("tm_lim"))/1000 
+    return MOI.get(model, MOI.RawParameter("tm_lim")) / 1000 
 end
 
 MOI.Utilities.supports_default_copy_to(::Optimizer, ::Bool) = true

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -287,6 +287,8 @@ end
 
 @testset "TimeLimitSec issue #110" begin
     model = GLPK.Optimizer(method = GLPK.SIMPLEX)
+    MOI.set(model, MOI.TimeLimitSec(), nothing)
+    @test MOI.get(model, MOI.RawParameter("tm_lim")) == typemax(Int32)
     MOI.set(model, MOI.TimeLimitSec(), 100)
     @test MOI.get(model, MOI.RawParameter("tm_lim")) == 100000
     @test MOI.get(model, MOI.TimeLimitSec()) == 100

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -285,6 +285,16 @@ end
     @test MOI.get(model, MOI.RawParameter("mip_gap")) == 0.001
 end
 
+@testset "TimeLimitSec issue #110" begin
+    model = GLPK.Optimizer(method = GLPK.SIMPLEX)
+    MOI.set(model, MOI.TimeLimitSec(), 100)
+    @test MOI.get(model, MOI.RawParameter("tm_lim")) == 100000
+    @test MOI.get(model, MOI.TimeLimitSec()) == 100
+    # conversion between ms and sec
+    MOI.set(model, MOI.RawParameter("tm_lim"), 100)
+    @test isapprox(MOI.get(model, MOI.TimeLimitSec()), 0.1)
+end
+
 @testset "RelativeGap" begin
     model = GLPK.Optimizer()
     MOI.Utilities.loadfromstring!(model, """


### PR DESCRIPTION
Bugfix for #110 
Is their also the desired behavior of getting back `nothing` when `TimeLimitSec` was called with `nothing` or is it okay to return a high number?