### PR TITLE
Add missing supports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GLPK"
 uuid = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 repo = "https://github.com/JuliaOpt/GLPK.jl.git"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/src/MOI_callbacks.jl
+++ b/src/MOI_callbacks.jl
@@ -18,6 +18,7 @@ function MOI.set(model::Optimizer, ::CallbackFunction, callback::Function)
     end)
     return
 end
+MOI.supports(::Optimizer, ::CallbackFunction) = true
 
 # ==============================================================================
 #    MOI callbacks
@@ -57,6 +58,8 @@ function MOI.set(model::Optimizer, ::MOI.LazyConstraintCallback, cb::Function)
     model.lazy_callback = cb
     return
 end
+MOI.supports(::Optimizer, ::MOI.LazyConstraintCallback) = true
+
 
 function MOI.submit(
     model::Optimizer,
@@ -77,6 +80,7 @@ function MOI.submit(
     _add_affine_constraint(inner, indices, coefficients, sense, rhs - f.constant)
     return
 end
+MOI.supports(::Optimizer, ::MOI.LazyConstraint{CallbackData}) = true
 
 # ==============================================================================
 #    MOI.UserCutCallback
@@ -86,6 +90,7 @@ function MOI.set(model::Optimizer, ::MOI.UserCutCallback, cb::Function)
     model.user_cut_callback = cb
     return
 end
+MOI.supports(::Optimizer, ::MOI.UserCutCallback) = true
 
 function MOI.submit(
     model::Optimizer,
@@ -112,8 +117,7 @@ function MOI.submit(
     )
     return
 end
-
-#
+MOI.supports(::Optimizer, ::MOI.UserCut{CallbackData}) = true
 
 # ==============================================================================
 #    MOI.HeuristicCallback
@@ -123,6 +127,7 @@ function MOI.set(model::Optimizer, ::MOI.HeuristicCallback, cb::Function)
     model.heuristic_callback = cb
     return
 end
+MOI.supports(::Optimizer, ::MOI.HeuristicCallback) = true
 
 function MOI.submit(
     model::Optimizer,
@@ -142,3 +147,4 @@ function MOI.submit(
     ret = ios_heur_sol(cb.callback_data.tree, solution)
     return ret == 0 ? MOI.HEURISTIC_SOLUTION_ACCEPTED : MOI.HEURISTIC_SOLUTION_REJECTED
 end
+MOI.supports(::Optimizer, ::MOI.HeuristicSolution{CallbackData}) = true

--- a/test/MOI_callbacks.jl
+++ b/test/MOI_callbacks.jl
@@ -47,6 +47,7 @@ end
                 lazy_called = true
                 x_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
                 y_val = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y)
+                @test MOI.supports(model, MOI.LazyConstraint(cb_data))
                 if y_val - x_val > 1 + 1e-6
                     MOI.submit(
                         model,
@@ -68,6 +69,7 @@ end
                     )
                 end
             end)
+            @test MOI.supports(model, MOI.LazyConstraintCallback())
             MOI.optimize!(model)
             @test lazy_called
             @test MOI.get(model, MOI.VariablePrimal(), x) == 1
@@ -142,6 +144,7 @@ end
                         accumulated += item_weights[i]
                     end
                 end
+                @test MOI.supports(model, MOI.UserCut(cb_data))
                 if accumulated > 10.0
                     MOI.submit(
                         model,
@@ -152,6 +155,7 @@ end
                     user_cut_submitted = true
                 end
             end)
+            @test MOI.supports(model, MOI.UserCutCallback())
             MOI.optimize!(model)
             @test user_cut_submitted
         end
@@ -200,6 +204,7 @@ end
             solution_rejected = false
             MOI.set(model, MOI.HeuristicCallback(), (cb_data) -> begin
                 x_vals = MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x)
+                @test MOI.supports(model, MOI.HeuristicSolution(cb_data))
                 if MOI.submit(
                     model,
                     MOI.HeuristicSolution(cb_data),
@@ -217,6 +222,7 @@ end
                     solution_rejected = true
                 end
             end)
+            @test MOI.supports(model, MOI.HeuristicCallback())
             MOI.optimize!(model)
             @test solution_accepted
             @test solution_rejected
@@ -276,6 +282,7 @@ end
                     MOI.get(model, MOI.ObjectiveBound())
                 )
             end)
+            @test MOI.supports(model, GLPK.CallbackFunction())
             MOI.optimize!(model)
         end
         @testset "LazyConstraint" begin


### PR DESCRIPTION
Now that callbacks can be used in JuMP's Automatic mode, we need to tell `copy_to` to pass them to the inner optimizer. 

x-ref https://github.com/JuliaOpt/JuMP.jl/issues/2124