### PR TITLE
Move to jll build of GLPK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ julia:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
 notifications:
   email: false
 branches:

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "~0.5"
-GLPK_jll = "4.65"
+GLPK_jll = "4.64"
 MathOptInterface = "~0.9.5"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,18 @@
 name = "GLPK"
 uuid = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 repo = "https://github.com/JuliaOpt/GLPK.jl.git"
-version = "0.12.1"
+version = "0.13.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+GLPK_jll = "e8aa6df9-e6ca-548a-97ff-1f85fc5b8b98"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "~0.5"
+GLPK_jll = "4.65"
 MathOptInterface = "~0.9.5"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BinaryProvider = "~0.5"
-GLPK_jll = "4.64"
+GLPK_jll = "~4.64.0"
 MathOptInterface = "~0.9.5"
 julia = "1"
 

--- a/src/GLPK.jl
+++ b/src/GLPK.jl
@@ -190,10 +190,14 @@ import Base.setindex!, Base.getindex
 
 ## Shared library interface setup
 #{{{
-if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
-    include("../deps/deps.jl")
+if VERSION < v"1.3"
+    if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
+        include("../deps/deps.jl")
+    else
+        error("GLPK not properly installed. Please run Pkg.build(\"GLPK\")")
+    end
 else
-    error("GLPK not properly installed. Please run Pkg.build(\"GLPK\")")
+    import GLPK_jll: libglpk
 end
 
 include("GLPK_constants.jl")
@@ -238,11 +242,13 @@ function version()
     return tuple(map(x->parse(Int, x), split(vstr, '.'))...)
 end
 
-include("../deps/verreq.jl")
+if VERSION < v"1.3"
+    include("../deps/verreq.jl")
 
-function __init__()
-    major_ver, minor_ver = version()
-    check_glpk_version(major_ver, minor_ver)
+    function __init__()
+        major_ver, minor_ver = version()
+        check_glpk_version(major_ver, minor_ver)
+    end
 end
 
 #}}}

--- a/src/GLPK.jl
+++ b/src/GLPK.jl
@@ -190,7 +190,7 @@ import Base.setindex!, Base.getindex
 
 ## Shared library interface setup
 #{{{
-if VERSION < v"1.3"
+if haskey(ENV,"JULIA_GLPK_LIBRARY_PATH") || VERSION < v"1.3"
     if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
         include("../deps/deps.jl")
     else
@@ -242,7 +242,7 @@ function version()
     return tuple(map(x->parse(Int, x), split(vstr, '.'))...)
 end
 
-if VERSION < v"1.3"
+if haskey(ENV,"JULIA_GLPK_LIBRARY_PATH") || VERSION < v"1.3"
     include("../deps/verreq.jl")
 
     function __init__()

--- a/test/glpk_tst_6.jl
+++ b/test/glpk_tst_6.jl
@@ -46,8 +46,9 @@ function cb_callback(tree::Ptr{Cvoid}, info::Ptr{Cvoid})
         @test GLPK.ios_pool_size(tree) == ps + 1
         GLPK.ios_add_row(tree, nothing, 0, Int32[1,2,3], Float64[7.0,6.0,5.0], GLPK.LO, 0.0)
         @test GLPK.ios_pool_size(tree) == ps + 2
-        GLPK.ios_del_row(tree, 1)
-        @test GLPK.ios_pool_size(tree) == ps + 1
+        # TODO(odow): works on GLPK 4.64, fails on GLPK 4.65:
+        # GLPK.ios_del_row(tree, 1)
+        # @test GLPK.ios_pool_size(tree) == ps + 1
         GLPK.ios_clear_pool(tree)
         @test GLPK.ios_pool_size(tree) == 0
     elseif reason == GLPK.IBRANCH

--- a/test/glpk_tst_6.jl
+++ b/test/glpk_tst_6.jl
@@ -46,9 +46,8 @@ function cb_callback(tree::Ptr{Cvoid}, info::Ptr{Cvoid})
         @test GLPK.ios_pool_size(tree) == ps + 1
         GLPK.ios_add_row(tree, nothing, 0, Int32[1,2,3], Float64[7.0,6.0,5.0], GLPK.LO, 0.0)
         @test GLPK.ios_pool_size(tree) == ps + 2
-        # TODO(odow): works on GLPK 4.64, fails on GLPK 4.65:
-        # GLPK.ios_del_row(tree, 1)
-        # @test GLPK.ios_pool_size(tree) == ps + 1
+        GLPK.ios_del_row(tree, 1)
+        @test GLPK.ios_pool_size(tree) == ps + 1
         GLPK.ios_clear_pool(tree)
         @test GLPK.ios_pool_size(tree) == 0
     elseif reason == GLPK.IBRANCH


### PR DESCRIPTION
Try out a JLL build of GLPK.

<s>I get a weird error: `ios_del_row` now fails.
```Julia
(GLPK) pkg> test GLPK
   Testing GLPK
 Resolving package versions...
Assertion failed: 0
Error detected in file draft/glpios01.c at line 1552
glpk_tst_6.jl: Error During Test at /Users/oscar/.julia/dev/GLPK/test/glpk_tst_6.jl:87
  Test threw exception
  Expression: GLPK.intopt(mip, params) == 0
  GLPKFatalError("GLPK call failed. All GLPK objects you defined so far are now invalidated.")
  Stacktrace:
   [1] _err_hook(::Ptr{Nothing}) at /Users/oscar/.julia/dev/GLPK/src/GLPK.jl:214
   [2] ios_del_row(::Ptr{Nothing}, ::Int32) at /Users/oscar/.julia/dev/GLPK/src/GLPK.jl:220
   [3] cb_callback(::Ptr{Nothing}, ::Ptr{Nothing}) at /Users/oscar/.julia/dev/GLPK/test/glpk_tst_6.jl:49
   [4] intopt(::Prob, ::IntoptParam) at /Users/oscar/.julia/dev/GLPK/src/GLPK.jl:220
   [5] glpk_tst_6() at /Users/oscar/.julia/dev/GLPK/test/glpk_tst_6.jl:87
   [6] top-level scope at /Users/oscar/.julia/dev/GLPK/test/glpk_tst_6.jl:94
   [7] include at ./boot.jl:328 [inlined]
   [8] include_relative(::Module, ::String) at ./loading.jl:1105
   [9] include(::Module, ::String) at ./Base.jl:31
   [10] include(::String) at ./client.jl:424
   [11] top-level scope at /Users/oscar/.julia/dev/GLPK/test/runtests.jl:15
   [12] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1107
   [13] top-level scope at /Users/oscar/.julia/dev/GLPK/test/runtests.jl:15
   [14] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1107
   [15] top-level scope at /Users/oscar/.julia/dev/GLPK/test/runtests.jl:12
```
</s>
x-ref: https://github.com/JuliaPackaging/Yggdrasil/pull/676
x-ref: https://github.com/JuliaPackaging/Yggdrasil/issues/509#issuecomment-605516668