### PR TITLE
Run test for setting bounds twice without bridges

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -129,11 +129,11 @@ end
     end
 
     @testset "set_lower_bound_twice" begin
-        MOIT.set_lower_bound_twice(OPTIMIZER, Float64)
+        MOIT.set_lower_bound_twice(GLPK.Optimizer(), Float64)
     end
 
     @testset "set_upper_bound_twice" begin
-        MOIT.set_upper_bound_twice(OPTIMIZER, Float64)
+        MOIT.set_upper_bound_twice(GLPK.Optimizer(), Float64)
     end
 end
 


### PR DESCRIPTION
With the new bridges for Semiinteger and Semicontinuous, `OPTIMIZER` now supports these sets. However, as they are bridged, GLPK does not see them as bounds hence no error is thrown so this tests fails with the bridges. To fix the tests with MOI master, GLPK is passed without any bridges.